### PR TITLE
Fix filtering numbers issue

### DIFF
--- a/app/controllers/available_phone_numbers_controller.rb
+++ b/app/controllers/available_phone_numbers_controller.rb
@@ -1,6 +1,6 @@
 class AvailablePhoneNumbersController < ApplicationController
   def index
-    area_code = params[:area_code]
+    area_code = params["area-code"]
     # TwilioClient is a thin wrapper for Twilio::REST::Client
     @phone_numbers = ::TwilioClient.available_phone_numbers(area_code)
   end

--- a/lib/twilio_client.rb
+++ b/lib/twilio_client.rb
@@ -16,8 +16,8 @@ class TwilioClient
   end
 
   def available_phone_numbers(area_code = '415')
-   client.available_phone_numbers.
-     get('US').local.list(area_code: area_code).take(10)
+    client.available_phone_numbers.
+      get('US').local.list(area_code: area_code).take(10)
   end
 
   def purchase_phone_number(phone_number)

--- a/spec/controllers/available_phone_numbers_controller_spec.rb
+++ b/spec/controllers/available_phone_numbers_controller_spec.rb
@@ -7,7 +7,7 @@ describe AvailablePhoneNumbersController do
       available_number = double("Available Number")
       allow(TwilioClient).to receive(:available_phone_numbers).with(area_code) {[available_number]}
 
-      get :index, area_code: area_code
+      get :index, "area-code" => area_code
       expect(assigns(:phone_numbers)).to eq [available_number]
     end
   end


### PR DESCRIPTION
@atbaker the issue was caused because the application was using `:area_code` instead of `"area-code"`, so that the filtering functionality was behaving incorrectly. As you can see in the next image, it is solved.

![call_tracking_rails](https://cloud.githubusercontent.com/assets/957202/9859335/9eeeb22e-5aeb-11e5-8a04-017e17d3373b.png)

Does this fix LGTY?