### PR TITLE
Change `leads` route URL to `call-tracking/forward-call`

### DIFF
--- a/app/controllers/call_tracking_controller.rb
+++ b/app/controllers/call_tracking_controller.rb
@@ -1,19 +1,19 @@
-class LeadsController < ApplicationController
+class CallTrackingController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  def create
+  def forward_call
     lead = Lead.create(lead_params)
-    forward_call(lead_source.forwarding_number)
+    render text: twilio_response.text
   end
 
   private
 
-  def forward_call(phone_number)
-    response = Twilio::TwiML::Response.new do |r|
+  def twilio_response
+    phone_number = lead_source.forwarding_number
+
+    Twilio::TwiML::Response.new do |r|
       r.Dial phone_number
     end
-
-    render text: response.text
   end
 
   def lead_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,13 @@ Rails.application.routes.draw do
 
   # Example of named route that can be invoked with purchase_url(id: product.id)
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
+  post 'call-tracking/forward-call' => 'call_tracking#forward_call', as: :forward_call
   get 'statistics/leads_by_source' => 'statistics#leads_by_source', as: :leads_by_source
   get 'statistics/leads_by_city' => 'statistics#leads_by_city', as: :leads_by_city
 
   # Example resource route (maps HTTP verbs to controller actions automatically):
   #   resources :products
   resources :lead_sources, only: [:create, :edit, :update]
-  resources :leads, only: [:create]
   resources :available_phone_numbers, only: [:index]
 
   # Example resource route with options:

--- a/spec/controllers/call_tracking_controller_spec.rb
+++ b/spec/controllers/call_tracking_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe LeadsController do
+describe CallTrackingController do
   describe "#create" do
 
     before do
@@ -10,12 +10,12 @@ describe LeadsController do
 
     it "creates a lead" do
       expect do
-        post :create, "Called" => '+12568417275', "Caller" => '+12568417333', "FromCity" => 'San Diego', "FromState" => 'CA'
+        post :forward_call, "Called" => '+12568417275', "Caller" => '+12568417333', "FromCity" => 'San Diego', "FromState" => 'CA'
       end.to change(Lead, :count).by(1)
     end
 
     it "renders a TwiML text response" do
-      post :create, "Called" => '+12568417275', "Caller" => '+12568417333', "FromCity" => 'San Diego', "FromState" => 'CA'
+      post :forward_call, "Called" => '+12568417275', "Caller" => '+12568417333', "FromCity" => 'San Diego', "FromState" => 'CA'
       expect(response.body).to eq("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response><Dial>+593 99 267 0240</Dial></Response>")
     end
   end


### PR DESCRIPTION
@atbaker as we discussed on #2, I changed the route URL to favor a more friendly name.

<img width="759" alt="1__tmux" src="https://cloud.githubusercontent.com/assets/957202/9860793/f22ed736-5af3-11e5-8a64-68b5acee7036.png">

Would you mind reviewing it please?

_Note: As soon as I got this merged, I'll update the tutorial accordingly._